### PR TITLE
Bugfix day 4 part 2

### DIFF
--- a/common/inputUtils.ts
+++ b/common/inputUtils.ts
@@ -7,11 +7,10 @@ function getInputLines(day: number): string[] {
         .filter(value => !!value.trim())
 }
 
-// TODO fix last line having trailing \n - causes day 4 part 2 to give wrong answer
 function getInputSplitByBlankLines(day: number): string[] {
     return readFileSync(resolve(__dirname, `../day${day}/input`), 'utf8')
         .split("\n\n")
-        .filter(value => !!value.trim())
+        .map(value => value.trim())
 }
 
 export {

--- a/day4/part2.ts
+++ b/day4/part2.ts
@@ -46,7 +46,7 @@ export class CredentialValidator {
         ],
         [
             "pid",
-            value => /\d{9}/.test(value)
+            value => /^\d{9}$/.test(value)
         ],
         [
             "cid",

--- a/day6/part2.ts
+++ b/day6/part2.ts
@@ -13,7 +13,7 @@ export default function part2(): number {
     const groups = getInputSplitByBlankLines(6);
     let total = 0;
     for(let group of groups) {
-        total += countQuestionsEveryoneAnswered(groupQuestionsAnswered(group.trim()));
+        total += countQuestionsEveryoneAnswered(groupQuestionsAnswered(group));
     }
 
     return total;


### PR DESCRIPTION
PID length validator didn't limit to 9 digits
Fix getInputSplitByBlankLines to trim out newline characters

Explanation: New line character caused last passport to be marked invalid even though it's valid. A single passport had 10 digit PID which should've been invalid but was marked valid. They cancelled out and gave the right answer.